### PR TITLE
Adding retry mechanism so that cloudevents are not lost when sent

### DIFF
--- a/source/config/config-redis.yaml
+++ b/source/config/config-redis.yaml
@@ -19,4 +19,4 @@ metadata:
   namespace: knative-sources
 data:
   # Configure the receive adapter with the number of consumers in a group
-  numConsumers: "5"
+  numConsumers: "5000"

--- a/source/pkg/adapter/adapter.go
+++ b/source/pkg/adapter/adapter.go
@@ -37,10 +37,10 @@ import (
 const (
 	// RedisStreamSourceEventType is the default RedisStreamSource CloudEvent type.
 	RedisStreamSourceEventType = "dev.knative.sources.redisstream"
-	blockms                    = 5000                    // block for 5s before timing out
-	count                      = 1                       // read one redis entry at a time
-	retryNumTimes              = 5                       // maximum number for retries  TODO: Can move this to config?
-	retryWaitPeriod            = 1000 * time.Millisecond // amount of time to wait (1s) TODO: Can move this to config?
+	blockms                    = 5000                  // block for 5s before timing out
+	count                      = 1                     // read one redis entry at a time
+	retryNumTimes              = 5                     // maximum number for retries  TODO: Can move this to config?
+	retryWaitPeriod            = 50 * time.Millisecond // amount of time to wait (50ms) TODO: Can move this to config?
 )
 
 func NewEnvConfig() adapter.EnvConfigAccessor {


### PR DESCRIPTION
Fixes https://github.com/knative-sandbox/eventing-redis/issues/34

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Adding retry via `ctx = cloudevents.ContextWithRetriesExponentialBackoff(ctx, retryWaitPeriod, retryNumTimes)`

Please refer to Issue to see load testing done.

cc: @lionelvillard @beemarie 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
