### PR TITLE
Upgrading engineerd/setup-kind to v0.5.0 due to deprecation in Github action environment

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           version: 'v1.19.0'
       - name: Setup kind
-        uses: engineerd/setup-kind@v0.4.0
+        uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.9.0"
           config: test/kind-config.yaml


### PR DESCRIPTION
Signed-off-by: Ansu Varghese <avarghese@us.ibm.com>

Fixes failing builds...