### PR TITLE
adding dialusername to support redis v6

### DIFF
--- a/source/README.md
+++ b/source/README.md
@@ -82,11 +82,15 @@ kubectl create ns redex
 
 Note: In addition to configuring your TLS Certificate, if you are using a cloud
 instance of Redis DB, you will need to set the appropriate address in
-[`redisstreamsource`](../samples/source/redisstreamsource.yaml) source yaml.
-Here's an example connection string:
+[`redisstreamsource`](../samples/source/redisstreamsource.yaml) source yaml. For redis v5 and older, no username must be specified:
 
 ```
-address: "rediss://$USERNAME:$PASSWORD@7f41ece8-ccb3-43df-b35b-7716e27b222e.b2b5a92ee2df47d58bad0fa448c15585.databases.appdomain.cloud:32086"
+address: "rediss://:password@7f41ece8-ccb3-43df-b35b-7716e27b222e.b2b5a92ee2df47d58bad0fa448c15585.databases.appdomain.cloud:32086"
+```
+
+For redis v6, a username is required:
+```
+address: "rediss://username:password@7f41ece8-ccb3-43df-b35b-7716e27b222e.b2b5a92ee2df47d58bad0fa448c15585.databases.appdomain.cloud:32086"
 ```
 
 Then, apply [`samples/source`](../samples/source) which creates an event-display

--- a/source/pkg/adapter/adapter.go
+++ b/source/pkg/adapter/adapter.go
@@ -244,7 +244,7 @@ func (a *Adapter) newPool(address string) *redis.Pool {
 					panic(err)
 				}
 				c, err = redis.Dial("tcp", opt.Addr,
-					//redis.DialUsername(opt.Username), //username needs to be empty for successful redis connection (v8 go-redis issue)
+					redis.DialUsername(opt.Username),
 					redis.DialPassword(opt.Password),
 					redis.DialTLSConfig(&tls.Config{
 						RootCAs: roots,


### PR DESCRIPTION
Fixes #152 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- adding dialusername support for redis v6.
- Do we need to support previous versions of redis? If so, I think we need to provide a way to make this optional.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
