### PR TITLE
Converting TLS Cert's config map into secret

### DIFF
--- a/source/config/500-controller.yaml
+++ b/source/config/500-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: ko://knative.dev/eventing-redis/source/cmd/receive_adapter
         - name: CONFIG_REDIS_NUMCONSUMERS
           value: config-redis
-        - name: CONFIG_TLS_TLSCERTIFICATE
-          value: config-tls
+        - name: SECRET_TLS_TLSCERTIFICATE
+          value: tls-secret
       terminationGracePeriodSeconds: 10
 

--- a/source/config/tls-secret.yaml
+++ b/source/config/tls-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tls-secret
+  namespace: knative-sources
+stringData:
+  # the data is abbreviated in this example
+  TLS_CERT: |+
+    -----BEGIN CERTIFICATE-----
+    -----END CERTIFICATE-----
+

--- a/source/pkg/reconciler/streamsource/config.go
+++ b/source/pkg/reconciler/streamsource/config.go
@@ -27,8 +27,8 @@ const (
 	configMapNameEnv    = "CONFIG_REDIS_NUMCONSUMERS"
 	redisConfigKey      = "numConsumers"
 	DefaultNumConsumers = "10"
-	tlsConfigMapNameEnv = "CONFIG_TLS_TLSCERTIFICATE"
-	tlsConfigKey        = "cert.pem"
+	tlsSecretNameEnv    = "SECRET_TLS_TLSCERTIFICATE"
+	tlsConfigKey        = "TLS_CERT"
 )
 
 // RedisConfig contains the configuration defined in the redis ConfigMap.
@@ -56,11 +56,11 @@ func ConfigMapName() string {
 	return cm
 }
 
-// TLSConfigMapName gets the name of the tls cert ConfigMap
-func TLSConfigMapName() string {
-	cm := os.Getenv(tlsConfigMapNameEnv)
+// TLSSecretName gets the name of the tls cert Secret
+func TLSSecretName() string {
+	cm := os.Getenv(tlsSecretNameEnv)
 	if cm == "" {
-		return "config-tls"
+		return "secret-tls"
 	}
 	return cm
 }
@@ -101,21 +101,19 @@ func GetRedisConfig(configMap map[string]string) (*RedisConfig, error) {
 	return config, nil
 }
 
-// GetTLSConfig returns the details of the TLS certificate.
-func GetTLSConfig(configMap map[string]string) (*TLSConfig, error) {
-	if len(configMap) == 0 {
+// GetTLSSecret returns the details of the TLS certificate.
+func GetTLSSecret(secret map[string][]byte) (*TLSConfig, error) {
+	if len(secret) == 0 {
 		return nil, fmt.Errorf("missing configuration")
 	}
 
+	//Convert byte to a string
 	config := &TLSConfig{
-		TLSCertificate: "",
+		TLSCertificate: string(secret[tlsConfigKey]),
 	}
 
-	err := configmap.Parse(configMap,
-		configmap.AsString(tlsConfigKey, &config.TLSCertificate),
-	)
-	if err != nil {
-		return nil, err
+	if config == nil {
+		return nil, nil
 	}
 
 	return config, nil

--- a/source/pkg/reconciler/streamsource/controller.go
+++ b/source/pkg/reconciler/streamsource/controller.go
@@ -88,14 +88,14 @@ func NewController(
 		logging.FromContext(ctx).With(zap.Error(err)).Info("Error reading Redis ConfigMap'")
 	}
 
-	// Get TLS config map and set TLS certificate, to pass data to receive adapter.
+	// Get TLS secret and set TLS certificate, to pass data to receive adapter.
 	// Not rolling out new adapters on watch change.
-	if _, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(ctx, TLSConfigMapName(), metav1.GetOptions{}); err == nil {
-		cmw.Watch(TLSConfigMapName(), func(configMap *v1.ConfigMap) {
-			r.updateTLSConfig(ctx, configMap)
-		})
+	if secret, err := kubeclient.Get(ctx).CoreV1().Secrets(system.Namespace()).Get(ctx, TLSSecretName(), metav1.GetOptions{}); err == nil {
+
+		r.updateTLSSecret(ctx, secret)
+
 	} else if !apierrors.IsNotFound(err) {
-		logging.FromContext(ctx).With(zap.Error(err)).Info("Error reading TLS ConfigMap'")
+		logging.FromContext(ctx).With(zap.Error(err)).Info("Error reading TLS Secret'")
 	}
 
 	logging.FromContext(ctx).Info("Setting up event handlers")

--- a/source/pkg/reconciler/streamsource/streamsource.go
+++ b/source/pkg/reconciler/streamsource/streamsource.go
@@ -132,8 +132,8 @@ func (r *Reconciler) updateRedisConfig(ctx context.Context, configMap *corev1.Co
 	r.numConsumers = redisConfig.NumConsumers
 }
 
-func (r *Reconciler) updateTLSConfig(ctx context.Context, configMap *corev1.ConfigMap) {
-	tlsConfig, err := GetTLSConfig(configMap.Data)
+func (r *Reconciler) updateTLSSecret(ctx context.Context, secret *corev1.Secret) {
+	tlsConfig, err := GetTLSSecret(secret.Data)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("Error reading TLS configuration", zap.Error(err))
 	}


### PR DESCRIPTION
- 🧽 Move the TLS Cert from a configmap into a kubernetes secret.

