### PR TITLE
config map one word

### DIFF
--- a/source/README.md
+++ b/source/README.md
@@ -47,7 +47,7 @@ step.
 You can also, configure the receive adapter with the number of consumers in a
 group, prior to installing the event source.
 
-Edit the [`config-redis`](config/config-redis.yaml) Config Map to edit the
+Edit the [`config-redis`](config/config-redis.yaml) ConfigMap to edit the
 `numConsumers` data key:
 
 ```


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- quick readme fix, ConfigMap is one word.


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->
