### PR TITLE
[release-1.7] fix verify codegen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,6 @@ require (
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/gomodule/redigo v1.8.3
 	github.com/google/go-cmp v0.5.7
-	github.com/hashicorp/go-cleanhttp v0.5.1
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.21.0
@@ -60,7 +58,9 @@ require (
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.7 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -18,11 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GO111MODULE=on
-
 source $(dirname $0)/../vendor/knative.dev/hack/library.sh
 
-readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
+readonly TMP_DIFFROOT="$(mktemp -d)"
 
 cleanup() {
   rm -rf "${TMP_DIFFROOT}"


### PR DESCRIPTION
- the go code in third_party was modifying the root go.mod file
- add an empty go.mod which is essentially like a .gitignore
