### PR TITLE
add redis DB number select Support

### DIFF
--- a/sink/pkg/receiver/receiver.go
+++ b/sink/pkg/receiver/receiver.go
@@ -106,12 +106,15 @@ func newPool(address string, tlscert string) *redis.Pool {
 					}),
 					redis.DialTLSSkipVerify(true),
 					redis.DialUseTLS(true),
+					redis.DialDatabase(opt.DB),
 				)
 				if err != nil {
 					panic(err)
 				}
 			} else {
-				c, err = redis.Dial("tcp", opt.Addr)
+				c, err = redis.Dial("tcp", opt.Addr,
+					redis.DialDatabase(opt.DB),
+				)
 				if err != nil {
 					panic(err)
 				}

--- a/source/pkg/adapter/adapter.go
+++ b/source/pkg/adapter/adapter.go
@@ -251,12 +251,15 @@ func (a *Adapter) newPool(address string) *redis.Pool {
 					}),
 					redis.DialTLSSkipVerify(true),
 					redis.DialUseTLS(true),
+					redis.DialDatabase(opt.DB),
 				)
 				if err != nil {
 					panic(err)
 				}
 			} else {
-				c, err = redis.Dial("tcp", opt.Addr)
+				c, err = redis.Dial("tcp", opt.Addr,
+					redis.DialDatabase(opt.DB),
+				)
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
Add the capability to select a Redis DB to use from the Address, [redisParse.ParseURL(address)](https://pkg.go.dev/github.com/go-redis/redis/v8@v8.11.4?utm_source=gopls#ParseURL) gets that info but it's not used later in the options of [redis.Dial(...)](https://pkg.go.dev/github.com/gomodule/redigo@v1.8.3/redis?utm_source=gopls#DialOption).

## Proposed Changes

- 🎁 Add support for redis database selection from standard redis uris
