### PR TITLE
XINFO GROUPS accepts response of 12 entries

### DIFF
--- a/pkg/source/redis/scan.go
+++ b/pkg/source/redis/scan.go
@@ -163,7 +163,7 @@ func ScanXInfoGroupReply(reply interface{}, err error) (StreamGroups, error) {
 			return nil, err
 		}
 
-		if len(entries) != 8 {
+		if len(entries) != 8 && len(entries) != 12 {
 			return nil, fmt.Errorf("unexpected group reply size (%d)", len(entries))
 		}
 


### PR DESCRIPTION
Since Redis 7.0 XINFO GROUPS returns 12 entries

Fixes #

https://github.com/knative-sandbox/eventing-redis/issues/385

## Proposed Changes
The parsing of the result of XINFO GROUPS shoudl accept length of 8 and 12.

**Release Note**

```release-note
🐛 "Fix unexpected group reply size (12)" on Redis 7.0
```
