### PR TITLE
Correct source & sink links in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ implementations, which offer ways to integrate Knative with
 For details about `RedisStreamSource` or `RedisStreamSink`, click on the links
 below:
 
-1. [`RedisStreamSource`](source)
-1. [`RedisStreamSink`](sink)
+1. [`RedisStreamSource`](config/source)
+1. [`RedisStreamSink`](config/sink)


### PR DESCRIPTION
Updated the paths to match the restructuring from #380

Fixes #

Links to source and sink in root readme were broken in #380 

## Proposed Changes

- Update link to source in root readme
- Update link to sink in root readme
