### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/config/sink/config-observability.yaml
+++ b/config/sink/config-observability.yaml
@@ -42,7 +42,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/config/source/config-observability.yaml
+++ b/config/source/config-observability.yaml
@@ -42,7 +42,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

xref https://github.com/knative/operator/pull/1342